### PR TITLE
Linux install instruction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,5 +12,7 @@ Download using the [GitHub .zip download](https://github.com/dracula/gimp/archiv
 
 #### Activating theme
 
-1. Copy theme folder (note the version suffix) `cp -r ~/gimp/Dracula/ /Applications/GIMP-2.10/Contents/Resources/share/gimp/2.0/themes/`
+1. Copy theme folder (note the version suffix):
+   - MacOS: `cp -r ~/gimp/Dracula/ /Applications/GIMP-2.10/Contents/Resources/share/gimp/2.0/themes/`
+   - Linux: `cp -r ~/gimp/Dracula/ ~/.config/GIMP/2.10/themes/`
 2. Activate under `Preferences > Interface > Theme > Dracula : OK`


### PR DESCRIPTION
Fix: Added separate instruction for Linux hosts, left MacOS instruction in tact, though moved to a separate line.